### PR TITLE
p4c_w1_codeup_1071

### DIFF
--- a/p4c_w1_codeup_1071
+++ b/p4c_w1_codeup_1071
@@ -1,0 +1,16 @@
+#p4c_1#codeup#write-up_#1071
+
+#include <stdio.h>
+ 
+int main()
+{
+	int a;
+	/*while, do, do while 반복문을 사용할 수 없다*/
+	reload:
+		scanf("%d", &a);
+		if(a!=0) {
+			printf("%d\n", a);
+			goto reload;
+		}
+	return 0; 
+}


### PR DESCRIPTION
#1071
C언어의 대표적인 반복문 구문인 while(), do(), do~while() 사용 금지.

대신 
goto + 레이블(label)
을 배워, 언제든지 레이블이 있는 곳으로 돌아갈 수 있다.
-> 반복문과 같은 역할을 한다.

#1071의 경우 코드도 짧고 지금은 어렵지 않지만
처음 goto와 레이블 개념을 접했을 때 생소했기 때문에
무조건 write-up에 포함했다. 더 익숙해져야 하기 때문



